### PR TITLE
Implemented `in` and `between` search options for request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 
 composer.lock
 .php_cs.cache
+.idea

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -136,7 +136,7 @@ class Builder
                 if (array_key_exists($column[$this->columnField], $this->columnAliases)) {
                     $column[$this->columnField] = $this->columnAliases[$column[$this->columnField]];
                 }
-                $operator = preg_match('~^\[(?<operator>[=!%<>]+)\].*$~', $value, $matches) ? $matches['operator'] : '=';
+                $operator = preg_match('~^\[(?<operator>[|=!%<>]+)\].*$~', $value, $matches) ? $matches['operator'] : '=';
                 if ($this->caseInsensitive) {
                     $searchColumn = "lower(" . $column[$this->columnField] . ")";
                     $filter = "lower(:filter_{$i})";
@@ -161,6 +161,10 @@ class Builder
                     case '=': // Equals (default); usage: [=]search_term
                     default:
                         $andX->add($query->expr()->eq($searchColumn, $filter));
+                        break;
+                    case '|': // Equals for multiple values; usage: [|]search_term
+                        $value = explode('[|]', $value);
+                        $andX->add($query->expr()->in($searchColumn, $filter));
                         break;
                 }
                 $query->setParameter("filter_{$i}", $value);


### PR DESCRIPTION
Added two different ways to search.
Using the separator `|` for values and `in` as query builder expression.
Request value example:
`
value1[|]value2[|]value3
`

Using the separator `:` for values and `between` as query builder expression.
Request value example:
`2019-01-01[:]2019-01-31`