### PR TITLE
PHP 7.2 compatibility

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -103,7 +103,7 @@ class Builder
     {
         $query = clone $this->queryBuilder;
         $columns = &$this->requestParams['columns'];
-        $c = count($columns);
+        $c = (is_array($columns) ? count($columns) : 0);
         // Search
         if (array_key_exists('search', $this->requestParams)) {
             if ($value = trim($this->requestParams['search']['value'])) {


### PR DESCRIPTION
On PHP 7.2 the parameter must be an array or an object that implements Countable.